### PR TITLE
refactor: chat context

### DIFF
--- a/apps/web/src/app/app/[app_id]/session/[session_id]/page.tsx
+++ b/apps/web/src/app/app/[app_id]/session/[session_id]/page.tsx
@@ -11,22 +11,19 @@ interface IProps {
 
 export default async function SessionPage({ params }: IProps) {
   const { app_id, session_id } = params
-  const { sessions, apps } = await getSession(session_id, app_id)
+  const { session, app } = await getSession(session_id, app_id)
 
   return (
     <>
       <div className="h-full w-full overflow-hidden">
         <Chat
-          sessionId={session_id}
-          sessionName={sessions.name}
-          appId={apps?.short_id || ''}
-          appName={apps?.name || ''}
-          appIcon={apps?.icon || ''}
-          apiSessionId={sessions.api_session_id}
-          initialMessages={safeParse(sessions.messages_str, [])}
+          mode="live"
+          app={app}
+          session={session}
+          initialMessages={safeParse(session.messages_str, [])}
         />
       </div>
-      <AppNotFound archived={apps?.archived || false} />
+      <AppNotFound archived={app?.archived || false} />
       <AddAppToWorkspace appId={app_id} />
     </>
   )

--- a/apps/web/src/app/app/[app_id]/settings/workflow/chat-debug.tsx
+++ b/apps/web/src/app/app/[app_id]/settings/workflow/chat-debug.tsx
@@ -6,6 +6,7 @@ import { Loader2Icon, Play } from 'lucide-react'
 import useSWRMutation from 'swr/mutation'
 
 import { fetcher } from '@/lib/utils'
+import { App } from '@/db/apps/schema'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import Chat from '@/components/chat/page'
@@ -21,14 +22,14 @@ function getApiSessionId(url: string, { arg }: { arg: WorkflowItem[] }) {
 }
 
 interface IProps {
-  appId: string
-  appName: string
-  appIcon: string
+  app: App
 }
 
-const ChatDebug = ({ appId, appName, appIcon }: IProps) => {
+const ChatDebug = ({ app }: IProps) => {
+  const { short_id: appId } = app
+
   const [open, setOpen] = React.useState(false)
-  const [apiSessionId, setApiSessionId] = React.useState()
+  const [apiSessionId, setApiSessionId] = React.useState(null)
   const [chatMessages, setChatMessages] = React.useState<Message[]>([])
   const sessionIdRef = React.useRef(`debug-${appId}`)
 
@@ -62,6 +63,15 @@ const ChatDebug = ({ appId, appName, appIcon }: IProps) => {
     }
   }
 
+  const session = React.useMemo(
+    () => ({
+      api_session_id: apiSessionId,
+      short_id: sessionIdRef.current,
+      name: '',
+    }),
+    [apiSessionId]
+  )
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <Button onClick={handleClick} disabled={isMutating}>
@@ -77,16 +87,12 @@ const ChatDebug = ({ appId, appName, appIcon }: IProps) => {
 md:max-w-xl"
       >
         <Chat
-          appName={appName}
-          appIcon={appIcon}
-          isDebug
-          apiSessionId={apiSessionId}
-          appId={appId}
-          sessionId={sessionIdRef.current}
-          sessionName=""
+          app={app}
+          mode="debug"
+          isConfigChanged={shouldResetApiSessionId}
+          session={session}
           initialMessages={chatMessages}
           setInitialMessages={setChatMessages}
-          isConfigChanged={shouldResetApiSessionId}
         />
       </SheetContent>
     </Sheet>

--- a/apps/web/src/app/app/[app_id]/settings/workflow/page.tsx
+++ b/apps/web/src/app/app/[app_id]/settings/workflow/page.tsx
@@ -65,7 +65,7 @@ export default async function Page({ params }: IProps) {
           </div>
           <div className="mt-4 flex items-center gap-2">
             <AddTaskButton />
-            <ChatDebug appId={app_id} appName={name} appIcon={icon} />
+            <ChatDebug app={appDetail} />
           </div>
         </div>
 

--- a/apps/web/src/app/demo/chat-debug/page.tsx
+++ b/apps/web/src/app/demo/chat-debug/page.tsx
@@ -2,16 +2,20 @@ import ChatDebug from '@/components/chat-debug'
 
 const ChatDebugPage = () => {
   const values = {
-    sessionId: '',
-    sessionName: '1',
-    appName: '222',
-    appIcon:
-      'https://backend.withcontext.ai/backend/upload/2023/04/65947928-68d6-4f64-99d9-0b98578fe4c6.jpeg',
-    appId: '11',
+    session: {
+      short_id: '',
+      name: '1',
+      api_session_id: '1',
+    },
+    app: {
+      name: '222',
+      icon: 'https://backend.withcontext.ai/backend/upload/2023/04/65947928-68d6-4f64-99d9-0b98578fe4c6.jpeg',
+      short_id: '11',
+    },
   }
   return (
     <div className="p-6">
-      <ChatDebug {...values} />
+      <ChatDebug {...values} mode="debug" />
     </div>
   )
 }

--- a/apps/web/src/components/chat-debug.tsx
+++ b/apps/web/src/components/chat-debug.tsx
@@ -15,7 +15,7 @@ const ChatDebug = (values: ChatProps) => {
         </Button>
       </SheetTrigger>
       <SheetContent className="bottom-6 right-6 top-auto h-4/5 w-11/12 sm:max-w-xl md:max-w-xl">
-        <Chat {...values} isDebug />
+        <Chat {...values} mode="debug" />
       </SheetContent>
     </Sheet>
   )

--- a/apps/web/src/components/chat/chat-card.tsx
+++ b/apps/web/src/components/chat/chat-card.tsx
@@ -10,6 +10,7 @@ import { cn, getAvatarBgColor, getFirstLetter } from '@/lib/utils'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 
 import Text from '../ui/text'
+import { useChatContext } from './chat-context'
 import { Markdown } from './markdown/markdown'
 
 interface IProps {
@@ -18,10 +19,6 @@ interface IProps {
   model_avatar?: string
   user_avatar?: string
   isEnd?: boolean
-  appId: string
-  appName: string
-  appIcon: string
-  isDebug?: boolean
 }
 
 const AlertErrorIcon = ({ className }: { className: string }) => (
@@ -75,7 +72,9 @@ const formatTime = (time: Date) => {
 }
 
 const ChatCard = (props: IProps) => {
-  const { message, error = '', isEnd, appName, appIcon, appId, isDebug } = props
+  const { message, error = '', isEnd } = props
+  const { app, mode, isLoading } = useChatContext()
+  const { short_id: appId, icon: appIcon, name: appName } = app ?? {}
   const isUser = message?.role === 'user'
   const showError = isEnd && error && !isUser
 
@@ -121,7 +120,8 @@ const ChatCard = (props: IProps) => {
             <div
               className={cn(
                 'max-w-[280px] rounded-lg p-4 sm:max-w-xs md:max-w-lg	lg:max-w-3xl xl:max-w-3xl',
-                isDebug && 'max-w-[240px] md:max-w-md lg:max-w-md xl:max-w-md',
+                mode === 'debug' &&
+                  'max-w-[240px] md:max-w-md lg:max-w-md xl:max-w-md',
                 isUser ? 'bg-primary' : 'bg-gray-100',
                 showError ? 'rounded-lg border border-red-500	bg-red-50' : ''
               )}

--- a/apps/web/src/components/chat/chat-card.tsx
+++ b/apps/web/src/components/chat/chat-card.tsx
@@ -73,7 +73,7 @@ const formatTime = (time: Date) => {
 
 const ChatCard = (props: IProps) => {
   const { message, error = '', isEnd } = props
-  const { app, mode, isLoading } = useChatContext()
+  const { app, mode } = useChatContext()
   const { short_id: appId, icon: appIcon, name: appName } = app ?? {}
   const isUser = message?.role === 'user'
   const showError = isEnd && error && !isUser

--- a/apps/web/src/components/chat/chat-context.tsx
+++ b/apps/web/src/components/chat/chat-context.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { createContext, PropsWithChildren, useContext } from 'react'
+
+import { ChatApp, ChatSession } from './types'
+
+export type ChatMode = 'live' | 'debug' | 'history'
+
+interface BaseChatContextType {
+  app: ChatApp | null
+  session: ChatSession
+  mode: ChatMode
+  isLoading?: boolean
+}
+
+interface LiveChatContextType extends BaseChatContextType {
+  mode: 'live'
+  isLoading: boolean
+}
+
+interface DebugChatContextType extends BaseChatContextType {
+  mode: 'debug'
+  isLoading: boolean
+}
+
+interface HistoryChatContextType extends BaseChatContextType {
+  mode: 'history'
+}
+
+type ChatContextType =
+  | LiveChatContextType
+  | DebugChatContextType
+  | HistoryChatContextType
+
+const ChatContext = createContext<ChatContextType>({} as ChatContextType)
+
+const ChatContextProvider = ({
+  children,
+  ...props
+}: PropsWithChildren<ChatContextType>) => (
+  <ChatContext.Provider value={props}>{children}</ChatContext.Provider>
+)
+
+const useChatContext = () => useContext(ChatContext)
+
+export { ChatContext, ChatContextProvider, useChatContext }

--- a/apps/web/src/components/chat/chat-header.tsx
+++ b/apps/web/src/components/chat/chat-header.tsx
@@ -1,8 +1,7 @@
-import { Info } from 'lucide-react'
-
 import { cn } from '@/lib/utils'
 
 import { Button } from '../ui/button'
+import { useChatContext } from './chat-context'
 
 interface IconBoxProps {
   children: React.ReactNode
@@ -21,21 +20,22 @@ export const IconBox = (props: IconBoxProps) => (
 )
 
 interface IProps {
-  name: string
-  isDebug?: boolean
   onRestart?: () => void
   disabledRestart?: boolean
 }
 
-const ChatHeader = ({ name, isDebug, onRestart, disabledRestart }: IProps) => {
+const ChatHeader = ({ onRestart, disabledRestart }: IProps) => {
+  const { session, mode } = useChatContext()
+
+  const { name } = session
   return (
     <div
       className={cn(
         'w-full flex-col border-slate-200 max-md:hidden sm:hidden lg:flex',
-        isDebug ? 'border-0' : 'border-b'
+        mode === 'debug' ? 'border-0' : 'border-b'
       )}
     >
-      {isDebug ? (
+      {mode === 'debug' ? (
         <div className="flex w-full items-center justify-between text-lg font-medium">
           Debug
           <Button

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -8,28 +8,27 @@ import { useEnterSubmit } from '@/hooks/use-enter-submit'
 
 import { Button } from '../ui/button'
 import { Textarea } from '../ui/textarea'
+import { useChatContext } from './chat-context'
 
 interface InputProps {
   input: string
-  setInput: (e: string) => void
-  onSubmit: (value: string) => void
-  isLoading: boolean
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void
   reload: () => void
   stop: () => void
   showResend?: boolean
-  isDebug?: boolean
+  handleInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
 }
 
 const ChatInput = ({
   input,
-  setInput,
   onSubmit,
-  isLoading,
   reload,
   stop,
-  isDebug = false,
   showResend,
+  handleInputChange,
 }: InputProps) => {
+  const { isLoading, mode } = useChatContext()
+  const isDebug = mode === 'debug'
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
 
   const { formRef, onKeyDown } = useEnterSubmit()
@@ -58,13 +57,11 @@ const ChatInput = ({
         )}
       </div>
       <form
-        onSubmit={async (e) => {
-          e.preventDefault()
+        onSubmit={(e) => {
           if (isDisabled) {
             return
           }
-          setInput('')
-          await onSubmit(input)
+          onSubmit(e)
         }}
         ref={formRef}
       >
@@ -74,7 +71,7 @@ const ChatInput = ({
             className="min-h-[40px]"
             placeholder="Type a message"
             value={input}
-            onChange={(e) => setInput(e.target.value)}
+            onChange={handleInputChange}
             onKeyDown={onKeyDown}
             minRows={1}
             maxRows={8}

--- a/apps/web/src/components/chat/chat-list.tsx
+++ b/apps/web/src/components/chat/chat-list.tsx
@@ -6,30 +6,19 @@ import { Message } from 'ai'
 import { cn } from '@/lib/utils'
 
 import ChatCard from './chat-card'
+import { useChatContext } from './chat-context'
 
 interface IProps {
   messages: Message[]
   error?: string
-  waiting: boolean
   scrollRef: Ref<HTMLDivElement>
   setAutoScroll: (s: boolean) => void
-  appId: string
-  appName: string
-  appIcon: string
-  isDebug?: boolean
 }
 
-const ChatList = ({
-  messages,
-  waiting,
-  scrollRef,
-  setAutoScroll,
-  error,
-  appId,
-  appName,
-  appIcon,
-  isDebug = false,
-}: IProps) => {
+const ChatList = ({ messages, scrollRef, setAutoScroll, error }: IProps) => {
+  const { mode, isLoading } = useChatContext()
+  const isDebug = mode === 'debug'
+
   return (
     <div
       className={cn(
@@ -46,20 +35,11 @@ const ChatList = ({
             key={message?.id}
             error={error}
             isEnd={index === messages.length - 1}
-            appName={appName}
-            appIcon={appIcon}
-            appId={appId}
-            isDebug={isDebug}
           />
         )
       })}
-      {waiting && (
-        <ChatCard
-          message={{ id: '', content: '', role: 'assistant' }}
-          appId={appId}
-          appName={appName}
-          appIcon={appIcon}
-        />
+      {isLoading && messages[messages.length - 1].role === 'user' && (
+        <ChatCard message={{ id: '', content: '', role: 'assistant' }} />
       )}
     </div>
   )

--- a/apps/web/src/components/chat/chat-list.tsx
+++ b/apps/web/src/components/chat/chat-list.tsx
@@ -38,7 +38,7 @@ const ChatList = ({ messages, scrollRef, setAutoScroll, error }: IProps) => {
           />
         )
       })}
-      {isLoading && messages[messages.length - 1].role === 'user' && (
+      {isLoading && messages[messages.length - 1]?.role === 'user' && (
         <ChatCard message={{ id: '', content: '', role: 'assistant' }} />
       )}
     </div>

--- a/apps/web/src/components/chat/types.ts
+++ b/apps/web/src/components/chat/types.ts
@@ -1,0 +1,6 @@
+import { App } from '@/db/apps/schema'
+import { Session } from '@/db/sessions/schema'
+
+export type ChatSession = Pick<Session, 'short_id' | 'api_session_id' | 'name'>
+
+export type ChatApp = Pick<App, 'short_id' | 'icon' | 'name'>

--- a/apps/web/src/db/sessions/actions.ts
+++ b/apps/web/src/db/sessions/actions.ts
@@ -234,7 +234,10 @@ export async function getSession(sessionId: string, appId?: string) {
       throw new Error('Session not found')
     }
 
-    return session
+    return {
+      session: session.sessions,
+      app: session.apps,
+    }
   } catch (error: any) {
     if (appId) {
       redirect(`/app/${appId}`)


### PR DESCRIPTION
- added ChatContext to prevent passing props repetitively
- renamed `getSession`'s return to `app` and `session` from `apps` and `sessions`
- added `mode` for `Chat` to provide distinct types for different use scenarios
- removed `waiting` and used provided `isLoading` and message orders to determine message loading indicator
- streamlined `ChatInput`