### PR TITLE
fix(messages): use Pool instead of neon from @neondatabase/serverless

### DIFF
--- a/apps/web/src/db/messages/actions.ts
+++ b/apps/web/src/db/messages/actions.ts
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation'
 import { and, asc, desc, eq } from 'drizzle-orm'
 
 import { auth } from '@/lib/auth'
+// why use pool at this action? see https://github.com/withcontext-ai/builder/pull/162
 import { db } from '@/lib/drizzle-pool'
 
 import { Message, MessagesTable, NewMessage } from './schema'

--- a/apps/web/src/db/messages/actions.ts
+++ b/apps/web/src/db/messages/actions.ts
@@ -4,7 +4,7 @@ import { redirect } from 'next/navigation'
 import { and, asc, desc, eq } from 'drizzle-orm'
 
 import { auth } from '@/lib/auth'
-import { db } from '@/lib/drizzle-edge'
+import { db } from '@/lib/drizzle-pool'
 
 import { Message, MessagesTable, NewMessage } from './schema'
 

--- a/apps/web/src/lib/drizzle-pool.ts
+++ b/apps/web/src/lib/drizzle-pool.ts
@@ -1,0 +1,9 @@
+import { Pool as PoolServerless } from '@neondatabase/serverless'
+import { drizzle as drizzleServerless } from 'drizzle-orm/neon-serverless'
+
+const pool = new PoolServerless({
+  connectionString: process.env.DATABASE_URL,
+  connectionTimeoutMillis: 10 * 1000, // wait 10s before timing out when connecting a new client
+})
+
+export const db = drizzleServerless(pool as PoolServerless)

--- a/apps/web/src/lib/drizzle-pool.ts
+++ b/apps/web/src/lib/drizzle-pool.ts
@@ -1,9 +1,9 @@
-import { Pool as PoolServerless } from '@neondatabase/serverless'
-import { drizzle as drizzleServerless } from 'drizzle-orm/neon-serverless'
+import { Pool } from '@neondatabase/serverless'
+import { drizzle } from 'drizzle-orm/neon-serverless'
 
-const pool = new PoolServerless({
+const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   connectionTimeoutMillis: 10 * 1000, // wait 10s before timing out when connecting a new client
 })
 
-export const db = drizzleServerless(pool as PoolServerless)
+export const db = drizzle(pool)


### PR DESCRIPTION
When messages's `raw` is large, the neon will report error.

![CleanShot 2023-09-11 at 20 20 37@2x](https://github.com/withcontext-ai/builder/assets/41784/6f32cbc4-0d20-4c89-b018-291c933042f4)
