### PR TITLE
fix: slack

### DIFF
--- a/apps/web/src/app/api/chat/process/route.ts
+++ b/apps/web/src/app/api/chat/process/route.ts
@@ -3,34 +3,11 @@ import { NextRequest, NextResponse } from 'next/server'
 export const runtime = 'edge'
 export const dynamic = 'force-dynamic'
 
-// just for mock
-// const PROCESS_DATA = [
-//   {
-//     key: 'tool-0',
-//     finished: true,
-//     succeed: true,
-//   },
-//   {
-//     key: 'tool-1',
-//     finished: true,
-//     succeed: false,
-//   },
-//   {
-//     id: 'tool-2',
-//     finished: false,
-//     success: false,
-//   },
-// ]
-
 // Get chat process
 export async function GET(req: NextRequest) {
   try {
     const query = req.nextUrl.searchParams
     const api_session_id = query.get('api_session_id') || ''
-
-    // TODO: get the real data from api service
-    // await new Promise((resolve) => setTimeout(resolve, 1000))
-    // return NextResponse.json({ success: true, data: PROCESS_DATA })
 
     let res = await fetch(
       `${process.env.AI_SERVICE_API_BASE_URL}/v1/chat/session/${api_session_id}/process`

--- a/apps/web/src/app/api/webhook/slack/redirect_uri/route.ts
+++ b/apps/web/src/app/api/webhook/slack/redirect_uri/route.ts
@@ -3,6 +3,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { SLACK_REDIRECT_URI } from '@/lib/const'
 import { createSlackClient, SlackUtils } from '@/lib/slack'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(req: NextRequest) {
   try {
     const query = req.nextUrl.searchParams


### PR DESCRIPTION
Dynamic server usage: Page couldn't be rendered statically because it used `nextUrl.searchParams`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error