### PR TITLE
fix: slack logic

### DIFF
--- a/apps/web/src/app/api/webhook/slack/redirect_uri/route.ts
+++ b/apps/web/src/app/api/webhook/slack/redirect_uri/route.ts
@@ -38,6 +38,7 @@ export async function GET(req: NextRequest) {
     const app_id = accessInfo.app_id
     const team_id = accessInfo.team?.id
     const access_token = accessInfo.access_token
+    const user_id = accessInfo.authed_user?.id ?? ''
     if (!app_id) throw new Error('app_id is undefined')
     if (!team_id) throw new Error('team_id is undefined')
     if (!access_token) throw new Error('app_id is undefined')
@@ -48,6 +49,19 @@ export async function GET(req: NextRequest) {
       team_id,
       access_token,
     })
+
+    // check if the user email from slack is same as the state value
+    const userInfo = await slack.getUserInfo(user_id)
+    const email = userInfo?.profile?.email
+    if (!email) {
+      throw new Error('email is undefined, add scope users:read.email')
+    }
+    const state = query.get('state') // the state value is our user's email who request to install this app
+    if (email !== state) {
+      throw new Error(
+        'The email you use to log in to Slack is inconsistent with the email you use to log in to Context Builder.'
+      )
+    }
 
     const teamInfo = await slack.client.team.info({ team: team_id })
     if (!teamInfo.team) throw new Error('team is undefined')
@@ -62,9 +76,7 @@ export async function GET(req: NextRequest) {
     }
     const slack_team = await slack.addOrUpdateTeam(team)
 
-    const user = {
-      user_id: accessInfo.authed_user?.id ?? '',
-    }
+    const user = { user_id }
     const slack_user = await slack.addOrUpdateUser(user)
 
     if (slack_user.is_admin === false) {

--- a/apps/web/src/components/settings/account.tsx
+++ b/apps/web/src/components/settings/account.tsx
@@ -1,16 +1,12 @@
 import Link from 'next/link'
-import useSWR from 'swr'
 
-import { fetcher } from '@/lib/utils'
+import useUser from '@/hooks/use-user'
 import { Button } from '@/components/ui/button'
 import UserProfileCard from '@/components/user-profile-card'
 
 function Profile() {
-  const { data, isLoading } = useSWR('/api/me/profile', fetcher)
-
-  const { emailAddresses, firstName, lastName, imageUrl } = data ?? {}
-  const name = [firstName || '', lastName || ''].join(' ').trim()
-  const email = emailAddresses?.[0].emailAddress
+  const { data, isLoading } = useUser()
+  const { email, name, imageUrl } = data
 
   if (isLoading) {
     return <UserProfileCard.Loading />

--- a/apps/web/src/components/settings/chat-apps.tsx
+++ b/apps/web/src/components/settings/chat-apps.tsx
@@ -2,12 +2,16 @@ import { Share2Icon } from 'lucide-react'
 
 import { SLACK_AUTHORIZE_URL } from '@/lib/const'
 import { flags } from '@/lib/flags'
+import useUser from '@/hooks/use-user'
 import { Button } from '@/components/ui/button'
 import LogosSlackIcon from '@/components/icons/LogosSlackIcon'
 
 import SlackTeamList from './slack-team-list'
 
 export default function ChatApps() {
+  const { data, isLoading } = useUser()
+  const { email } = data
+
   return (
     <div className="space-y-8 px-6 py-4">
       <h2 className="text-lg font-semibold">Chat apps</h2>
@@ -21,8 +25,11 @@ export default function ChatApps() {
                   <LogosSlackIcon className="mr-4 h-6 w-6 shrink-0" />
                   <div className="font-medium">Slack</div>
                 </div>
-                <Button asChild>
-                  <a href={SLACK_AUTHORIZE_URL} target="_blank">
+                <Button asChild disabled={isLoading}>
+                  <a
+                    href={`${SLACK_AUTHORIZE_URL}&state=${email}`}
+                    target="_blank"
+                  >
                     <Share2Icon className="mr-2 h-4 w-4" />
                     Connect
                   </a>

--- a/apps/web/src/hooks/use-user.ts
+++ b/apps/web/src/hooks/use-user.ts
@@ -1,0 +1,22 @@
+import useSWR from 'swr'
+
+import { fetcher } from '@/lib/utils'
+
+export default function useUser() {
+  const { data, isLoading } = useSWR('/api/me/profile', fetcher, {
+    revalidateOnFocus: true,
+  })
+
+  const { emailAddresses, firstName, lastName, imageUrl } = data ?? {}
+  const name = [firstName || '', lastName || ''].join(' ').trim()
+  const email = emailAddresses?.[0].emailAddress
+
+  return {
+    isLoading,
+    data: {
+      email,
+      name,
+      imageUrl,
+    },
+  }
+}

--- a/apps/web/src/lib/slack.ts
+++ b/apps/web/src/lib/slack.ts
@@ -481,7 +481,6 @@ export class SlackUtils {
       )
       .orderBy(desc(SlackUserAppsTable.updated_at))
       .limit(1)
-    console.log('currentSession:', currentSession)
     return currentSession
   }
 }

--- a/apps/web/src/lib/slack.ts
+++ b/apps/web/src/lib/slack.ts
@@ -457,21 +457,31 @@ export class SlackUtils {
       .select({
         session_id: SessionsTable.short_id,
         api_session_id: SessionsTable.api_session_id,
+        slack_team_app_id: SlackTeamAppsTable.short_id,
       })
       .from(SlackUserAppsTable)
-      .innerJoin(
+      .leftJoin(
         SessionsTable,
         eq(SessionsTable.short_id, SlackUserAppsTable.context_session_id)
+      )
+      .leftJoin(
+        SlackTeamAppsTable,
+        and(
+          eq(SlackTeamAppsTable.app_id, this.app_id),
+          eq(SlackTeamAppsTable.team_id, this.team_id)
+        )
       )
       .where(
         and(
           eq(SlackUserAppsTable.app_id, this.app_id),
           eq(SlackUserAppsTable.team_id, this.team_id),
-          eq(SlackUserAppsTable.user_id, user_id)
+          eq(SlackUserAppsTable.user_id, user_id),
+          eq(SessionsTable.archived, false)
         )
       )
       .orderBy(desc(SlackUserAppsTable.updated_at))
       .limit(1)
+    console.log('currentSession:', currentSession)
     return currentSession
   }
 }


### PR DESCRIPTION
- Warn user if the email at Slack is inconsistent with the email in our db.
- Tell user to start a new chat at Slack if something wrong happens like session removed or app unlinked.
- Redirect to the failed page with error message if user click the cancel button at Slack while OAuth.